### PR TITLE
Bump Spectre.Console.Cli to 0.55.0 and fix breaking change

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Zio" Version="0.22.1" />

--- a/src/Test262Harness.Console/Program.cs
+++ b/src/Test262Harness.Console/Program.cs
@@ -53,7 +53,7 @@ internal sealed class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
         public string SettingsFile { get; set; } = "";
     }
 
-    public override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] Settings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] Settings settings, CancellationToken cancellationToken)
     {
         TestSuiteGeneratorOptions? options = null;
         var settingsFilePath = Path.Combine(Environment.CurrentDirectory, settings.SettingsFile);


### PR DESCRIPTION
## Summary
- Bumps Spectre.Console.Cli from 0.53.1 to 0.55.0 (supersedes #128)
- Fixes compilation error caused by `AsyncCommand<T>.ExecuteAsync` changing from `public` to `protected` in 0.55.0
- Changes `GenerateCommand.ExecuteAsync` override from `public` to `protected` to match

## Test plan
- [x] Solution builds successfully locally
- [ ] CI passes on both ubuntu-latest and windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)