### PR TITLE
Bump Verify.NUnit to 31.24.1 and pin LF endings for snapshot files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,8 @@
 *.sh      eol=lf
 *.conf    eol=lf
 dotnet-test-nunit eol=lf
+
+# Verify snapshot files must keep LF line endings; Verify.NUnit >= 31.21.0
+# rejects CR in these files instead of normalizing it.
+*.verified.* eol=lf
+*.received.* eol=lf

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.20.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.24.1" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="Zio" Version="0.24.0" />
     <PackageVersion Include="ZString" Version="2.6.0" />


### PR DESCRIPTION
## Summary
- Bumps `Verify.NUnit` from 31.20.0 to 31.24.1 (same target version as #159, which failed Windows CI).
- Adds `.gitattributes` rules pinning `eol=lf` for `*.verified.*` / `*.received.*` snapshot files.

## Problem
As of Verify 31.21.0, Verify rejects a `\r` in verified files instead of normalizing it (see [Verify #1762](https://github.com/VerifyTests/Verify/pull/1762)). Our `.gitattributes` only had `* text=auto`, so on Windows checkouts with `core.autocrlf=true` (the default for `windows-latest` GitHub runners), the `.verified.cs` snapshots under `test/Test262Harness.Tests/Snapshots` get checked out with CRLF, and `TestSuiteGeneratorTests` fails with:

```
System.Exception : Verified file must use \n line endings, but it contains a \r (carriage return).
```

This is exactly what broke #159's `windows-latest` job.

## Fix
Same approach used to fix this in Jint: [sebastienros/jint#2647](https://github.com/sebastienros/jint/pull/2647). Pin `eol=lf` on the snapshot file patterns so they always check out with LF regardless of platform/`core.autocrlf`, independent of the dependency bump.

## Test plan
- [x] `dotnet test test/Test262Harness.Tests` passes locally on Windows (13/13, including all `TestSuiteGeneratorTests`) after forcing a re-checkout of the snapshot files with the new `.gitattributes` rule (confirmed LF-only via re-checkout).
- [ ] CI green on both `windows-latest` and `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)