### PR TITLE
Bump checkout to v7 and upload-artifact to v7 in generated workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,20 +36,20 @@ jobs:
         with:
           dotnet-version: |
             10.0
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
       - name: 'Publish: test-results'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Windows'
         with:
           name: test-results
           path: artifacts/test-results
       - name: 'Publish: packages'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Windows'
         with:
           name: packages
@@ -62,20 +62,20 @@ jobs:
         with:
           dotnet-version: |
             10.0
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
       - name: 'Publish: test-results'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Windows'
         with:
           name: test-results
           path: artifacts/test-results
       - name: 'Publish: packages'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: runner.os == 'Windows'
         with:
           name: packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           dotnet-version: |
             10.0
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
   ubuntu-latest:
@@ -49,6 +49,6 @@ jobs:
         with:
           dotnet-version: |
             10.0
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -45,13 +45,78 @@ class CustomGitHubActionsAttribute : GitHubActionsAttribute
     {
         var job = base.GetJobs(image, relevantTargets);
 
-        var newSteps = new List<GitHubActionsStep>(job.Steps);
+        // Nuke pins the checkout / upload-artifact action versions to its own release. Swap them for
+        // version-pinned custom steps so the generated workflows track the latest action majors
+        // independently of the Nuke version we happen to build with.
+        var newSteps = new List<GitHubActionsStep>();
+        foreach (var step in job.Steps)
+        {
+            newSteps.Add(step switch
+            {
+                GitHubActionsCheckoutStep => new PinnedUsesStep("actions/checkout@v7"),
+                GitHubActionsArtifactStep artifact => new PinnedUploadArtifactStep(artifact.Name, artifact.Path, artifact.Condition),
+                _ => step,
+            });
+        }
 
         // only need to list the ones that are missing from default image
         newSteps.Insert(0, new GitHubActionsSetupDotNetStep(["10.0"]));
 
         job.Steps = newSteps.ToArray();
         return job;
+    }
+}
+
+/// <summary>Emits a bare <c>- uses: &lt;action&gt;</c> step, letting us pin an action version Nuke would otherwise hard-code.</summary>
+class PinnedUsesStep : GitHubActionsStep
+{
+    public PinnedUsesStep(string uses)
+    {
+        Uses = uses;
+    }
+
+    string Uses { get; }
+
+    public override void Write(CustomFileWriter writer)
+    {
+        writer.WriteLine($"- uses: {Uses}");
+    }
+}
+
+/// <summary>Reproduces Nuke's upload-artifact step (name / condition / path) but on a pinned action version.</summary>
+class PinnedUploadArtifactStep : GitHubActionsStep
+{
+    public PinnedUploadArtifactStep(string name, string path, string? condition)
+    {
+        Name = name;
+        Path = path;
+        Condition = condition;
+    }
+
+    string Name { get; }
+    string Path { get; }
+    string? Condition { get; }
+
+    public override void Write(CustomFileWriter writer)
+    {
+        writer.WriteLine($"- name: 'Publish: {Name}'");
+
+        using (writer.Indent())
+        {
+            writer.WriteLine("uses: actions/upload-artifact@v7");
+
+            if (!string.IsNullOrWhiteSpace(Condition))
+            {
+                writer.WriteLine($"if: {Condition}");
+            }
+
+            writer.WriteLine("with:");
+            using (writer.Indent())
+            {
+                writer.WriteLine($"name: {Name}");
+                writer.WriteLine($"path: {Path}");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Nuke hard-codes the `actions/checkout` (`@v6`) and `actions/upload-artifact` (`@v5`) versions to its own release. This overrides them in the `CustomGitHubActions` attribute with version-pinned custom steps — the same pattern already used for `setup-dotnet` — so the generated workflows track the latest action majors regardless of the Nuke version, and regeneration stays stable.

`build.yml` / `pr.yml` regenerated via `--generate-configuration`; the only diff is the action versions (`checkout` → **v7**, `upload-artifact` → **v7**). `setup-dotnet` is already on the latest major (`@v5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)